### PR TITLE
FIX added debouncer for touchscreen multiclick bug

### DIFF
--- a/index.js
+++ b/index.js
@@ -13426,5 +13426,16 @@ function onClick(event) {
     neutralClick();
   }
 }
+
+const debounce = (func, delay) => {
+  let debounceTimer
+
+  return function () {
+    const context = this
+    clearTimeout(debounceTimer)
+    debounceTimer = setTimeout(() => func(), delay);
+  }
+} 
+
 window.addEventListener("click", onClick);
-window.addEventListener("touchstart", onClick);
+window.addEventListener("touchstart", debouncer(() => onClick, 200));


### PR DESCRIPTION
Originally on samsung 20FE, touching a letter would register as 2 clicks.
Added a debouncer function onto the event listener for "touchstart" set at 200 ms.